### PR TITLE
Hoisting the license-header and copyright notice to an apropriate level

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,22 @@ You can adjust these parameters according to your experiments and computational 
 python validate.py --FOLDS 0,1,2,3,4 --NAME EXP_NAME
 ```
 
+**Copyright and license**
+
+Copyright 2023 Diagnostic Image Analysis Group (DIAG), Radboudumc, Nijmegen, The Netherlands
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 **Note**
 Source code for Probabilistic Attention U-Net and preprocessings are adopted from this repository: [DIAGNijmegen/prostateMR_3D-CAD-csPCa](https://github.com/DIAGNijmegen/prostateMR_3D-CAD-csPCa).
 


### PR DESCRIPTION
Putting the LICENSE text and copyright notice in the readme so it can be found more easily,